### PR TITLE
Implement command to make diff between changelog versions.

### DIFF
--- a/commands/changes.js
+++ b/commands/changes.js
@@ -101,7 +101,7 @@ exports.handler = (argv) => {
     return error("The previous version was not found in the CHANGES.md file.");
   }
 
-  const filePath = path.join(outputPath, `${baseVersion}.txt`);
+  const filePath = path.join(outputPath, `changes.txt`);
   fs.writeFileSync(
     filePath,
     changesFile


### PR DESCRIPTION

### Description
This command writes a file with the diff between the specified version (or `package.json` version, if omitted) and the last version.

```
$ equip changes -h

equip changes

Operations with Equip changelogs.

Options:
      --version      Show version number                               [boolean]
      --versionType  The type of version (e.g. 'major', 'minor', 'patch')
                                                     [string] [default: "patch"]
      --baseVersion  The base version to be compared. Leave empty for auto. The
                     version in the package.json will be considered.
                                                      [string] [default: "auto"]
      --output       The output file where the changes will be written to.
                                                         [string] [default: "."]
      --env          Which env should be considered (e.g. 'env', 'staging',
                     'release').                       [string] [default: "dev"]
  -h, --help         Show help                                         [boolean]
```

### Changes proposed in this pull request
- Implement a command to make diffs between changelog entries.